### PR TITLE
Add comptime if/for/assert statement modifiers

### DIFF
--- a/syntaxes/mojo.syntax.json
+++ b/syntaxes/mojo.syntax.json
@@ -132,6 +132,17 @@
           }
         },
         {
+          "match": "\\b(comptime)\\s+(if|for|assert)\\b",
+          "captures": {
+            "1": {
+              "name": "storage.modifier.declaration.python"
+            },
+            "2": {
+              "name": "keyword.control.flow.python"
+            }
+          }
+        },
+        {
           "match": "\\b(var|let|alias|comptime) \\s*([[:alpha:]_]\\w*)\\b",
           "captures": {
             "1": {
@@ -1092,11 +1103,14 @@
       ]
     },
     "generator": {
-      "comment": "Match \"for ... in\" construct used in generators and for loops to\ncorrectly identify the \"in\" as a control flow keyword.\n",
-      "begin": "\\bfor\\b",
+      "comment": "Match \"for ... in\" construct used in generators and for loops to\ncorrectly identify the \"in\" as a control flow keyword.\nCapture 0 = entire match (e.g. \"for\" or \"comptime for\"), capture 1 = optional \"comptime\" prefix.\nWhen \"comptime\" is absent, capture 1 is empty and its scope is not applied.\n",
+      "begin": "(?:\\b(comptime)\\s+)?\\bfor\\b",
       "beginCaptures": {
         "0": {
           "name": "keyword.control.flow.python"
+        },
+        "1": {
+          "name": "storage.modifier.declaration.python"
         }
       },
       "end": "\\bin\\b",

--- a/tests/comptime_statements.mojo
+++ b/tests/comptime_statements.mojo
@@ -2,19 +2,19 @@
 
 # comptime as statement modifier for if
 comptime if x > 3:
-# TODO <- storage.modifier.declaration.python
-# TODO    ^^ keyword.control.flow.python
+# <- storage.modifier.declaration.python
+#        ^^ keyword.control.flow.python
 
 # comptime as statement modifier for for
 comptime for x in range(10):
-# TODO <- storage.modifier.declaration.python
-# TODO    ^^^ keyword.control.flow.python
-# TODO          ^^ keyword.control.flow.python
+# <- storage.modifier.declaration.python
+#        ^^^ keyword.control.flow.python
+#              ^^ keyword.control.flow.python
 
 # comptime as statement modifier for assert
 comptime assert x > 0
-# TODO <- storage.modifier.declaration.python
-# TODO    ^^^^^^ keyword.control.flow.python
+# <- storage.modifier.declaration.python
+#        ^^^^^^ keyword.control.flow.python
 
 # comptime tuple destructuring (bare)
 comptime a, b = func()


### PR DESCRIPTION
## Summary
- Add `comptime` as a statement modifier for `if`, `for`, and `assert` keywords
- Update the `for...in` generator rule to support `comptime for x in range(...):`
- Enable corresponding test assertions in `tests/comptime_statements.mojo`

Implements the syntax highlighting portion of the [parameter-to-comptime proposal](https://github.com/modularml/modular/blob/main/oss/modular/mojo/proposals/parameter-to-comptime.md).

## Test plan
- [x] `npm test` passes — baseline and new comptime statement tests
- [ ] Tuple destructuring tests (`comptime a, b = ...` and `comptime (a, b) = ...`) to follow in a separate PR


🤖 Generated with [Claude Code](https://claude.com/claude-code)

FIXES MOCO-3323